### PR TITLE
Multiple outputs instead of multiple bundles

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,27 +1,19 @@
 import svelte from 'rollup-plugin-svelte';
 
 export default [
-	// ES module version, for modern browsers
 	{
 		input: ['src/main-a.js', 'src/main-b.js'],
-		output: {
+		output: [{
+			// ES module version, for modern browsers
 			dir: 'public/module',
 			format: 'es',
 			sourcemap: true
-		},
-		plugins: [svelte()],
-		experimentalCodeSplitting: true,
-		experimentalDynamicImport: true
-	},
-
-	// SystemJS version, for older browsers
-	{
-		input: ['src/main-a.js', 'src/main-b.js'],
-		output: {
+		}, {
+			// SystemJS version, for older browsers
 			dir: 'public/nomodule',
 			format: 'system',
 			sourcemap: true
-		},
+		}],
 		plugins: [svelte()],
 		experimentalCodeSplitting: true,
 		experimentalDynamicImport: true


### PR DESCRIPTION
Runs a bit faster since rollup only has to analyze once, and it generates identical output this way.

Also less chance of fat-fingering config changes if there's only one config to modify.